### PR TITLE
add mongo in docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ RUN useradd \
         --home /it-dgc-verifier-service \
         --shell /bin/bash \
         dgc \
-    && chown --recursive dgc:root /it-dgc-verifier-service \   
+    && chown --recursive dgc:root /it-dgc-verifier-service \
     && chmod -R g+rwx /it-dgc-verifier-service
 USER dgc
 
 
-ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /it-dgc-verifier-service/app.jar --spring.config.location=file:/it-dgc-verifier-service/config/application.properties" ]
+ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /it-dgc-verifier-service/app.jar --spring.config.location=classpath:/,file:/it-dgc-verifier-service/config/" ]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Once the requirements above shown are satisfied open a shell with working direct
 ```shell script
 docker-compose up --build
 ```
+
+##### Mongodb for testing
+Before running Integration test launch MongoDB
+
+```shell script
+docker-compose up mongo
+```
+
 #### Dependencies
 
 The project has been implemented in [Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html).

--- a/config/.gitkeep
+++ b/config/.gitkeep
@@ -1,0 +1,1 @@
+# track this folder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,17 @@ services:
       - 9080:9080        
     environment:
       - SERVER_PORT=9080
-      - MONGO_DB_URI=mongodb://host.docker.internal:27017/DGC-dev
+      - MONGO_DB_URI=mongodb://mongo:27017/DGC-dev
     volumes:
-      - ./it-dgc-verifier-service/config:/it-dgc-verifier-service/config
+      - ./config:/it-dgc-verifier-service/config
+    networks:
+      - backend_net
+
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
     networks:
       - backend_net
   

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,6 +2,8 @@
 spring.application.name=Italian services for DGC verifier apps
 server.servlet.context-path=/
 
+spring.profiles.active=test
+
 server.port=9080
 
 #MONGODB


### PR DESCRIPTION
+ base mongo service in docker-compose.yml
* update configurations to use WORKSPACE/config as config folder
  to suport application.properties instead of replacing

<!--- IMPORTANT: Please review [how to contribute](https://github.com/ministero-salute/it-eucert-verifier-service/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR tackles:

- ...
- ...
- ...

In particular, the ...

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/ministero-salute/it-eucert-verifier-service/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #30
